### PR TITLE
Implement project showcase

### DIFF
--- a/src/components/ProjectCards.tsx
+++ b/src/components/ProjectCards.tsx
@@ -87,23 +87,25 @@ import {
               padding={2}
               justifyContent={'space-between'}
               alignItems={'center'}>
-              <Button
-                flex={1}
-                fontSize={'sm'}
-                rounded={'full'}
-                bg={'blue.400'}
-                color={'white'}
-                boxShadow={
-                  '0px 1px 25px -5px rgb(66 153 225 / 48%), 0 10px 10px -5px rgb(66 153 225 / 43%)'
-                }
-                _hover={{
-                  bg: 'blue.500',
-                }}
-                _focus={{
-                  bg: 'blue.500',
-                }}>
-                See More
-              </Button>
+              <Link href={`/ProjectDetails/${projectProp.id}`}> 
+                <Button
+                  flex={1}
+                  fontSize={'sm'}
+                  rounded={'full'}
+                  bg={'blue.400'}
+                  color={'white'}
+                  boxShadow={
+                    '0px 1px 25px -5px rgb(66 153 225 / 48%), 0 10px 10px -5px rgb(66 153 225 / 43%)'
+                  }
+                  _hover={{
+                    bg: 'blue.500',
+                  }}
+                  _focus={{
+                    bg: 'blue.500',
+                  }}>
+                  See More
+                </Button>
+              </Link>
             </Stack>
           </Stack>
         </Stack>

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,42 @@
+export interface Project {
+  id: number;
+  name: string;
+  githubId: string;
+  githubUrl: string;
+  hashtags: string[];
+  description: string;
+  logo: string;
+}
+
+import robotlogo from '../images/logos/robotlogo.jpg';
+import ecommLogo from '../images/logos/robotlogo.jpg';
+
+export const projects: Project[] = [
+  {
+    id: 0,
+    name: 'Bet Robot',
+    githubId: '@roboapostas - Privated',
+    githubUrl: 'https://github.com/alangomessilva/roboapostas',
+    hashtags: ['Football', 'Node', 'Bet'],
+    description: 'This Robot, maked in NodeJs, make football Hints for apply in Bets House! ',
+    logo: robotlogo.toString(),
+  },
+  {
+    id: 1,
+    name: 'E-Commerce POC ',
+    githubId: 'EcommercePoc',
+    githubUrl: 'https://github.com/alangomessilva/',
+    hashtags: ['Ecomm', 'Poc', 'Java'],
+    description: 'E-Commerce POC - Building ',
+    logo: ecommLogo.toString(),
+  },
+  {
+    id: 2,
+    name: 'Hybris Addon Poc',
+    githubId: 'hybrisAddon',
+    githubUrl: 'https://github.com/alangomessilva/hybrisAddon',
+    hashtags: ['Ecomm', 'Hybris', 'Java'],
+    description: 'Addon to Hybris - Building ',
+    logo: ecommLogo.toString(),
+  },
+];

--- a/src/pages/ProjectDetails.tsx
+++ b/src/pages/ProjectDetails.tsx
@@ -1,24 +1,41 @@
 import {
   Container,
   Stack,
+  Heading,
+  Text,
+  Image,
+  Link,
 } from '@chakra-ui/react';
-import { useParams } from "react-router-dom"
+import { useParams } from "react-router-dom";
+import { projects } from "../data/projects";
 
 
 
 export default function ProjectDetails() {
-  const {id} = useParams();
+  const { id } = useParams<{ id: string }>();
+  const project = projects.find((p) => p.id === Number(id));
+
+  if (!project) {
+    return (
+      <Container maxW={'2xl'}>
+        <Stack textAlign={'center'} align={'center'} py={{ base: 20, md: 14 }}>
+          <Heading>Project not found</Heading>
+        </Stack>
+      </Container>
+    );
+  }
 
   return (
     <Container maxW={'2xl'}>
       <Stack
         textAlign={'center'}
         align={'center'}
+        spacing={4}
         py={{ base: 20, md: 14 }}>
-          <div>
-            {id}
-          </div>
-
+        <Heading>{project.name}</Heading>
+        <Image src={project.logo} boxSize="200px" objectFit="cover" alt={project.name} />
+        <Text>{project.description}</Text>
+        <Link href={project.githubUrl} color={'blue.400'}>View on GitHub</Link>
       </Stack>
     </Container>
   );

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -4,44 +4,11 @@ import {
   Stack,
 } from '@chakra-ui/react';
 import ProjectCards from "../components/ProjectCards"
-import robotlogo from "../images/logos/robotlogo.jpg"
-import ecommLogo from "../images/logos/robotlogo.jpg"
-
-const projects = [{
-  id: 0,
-  name: 'Bet Robot',
-  githubId: '@roboapostas - Privated',
-  githubUrl: 'https://github.com/alangomessilva/roboapostas',
-  hashtags: ["Football", "Node", "Bet"],
-  description:
-    'This Robot, maked in NodeJs, make football Hints for apply in Bets House! ',
-  logo: robotlogo.toString()
-},
-{
-  id: 1,
-  name: 'E-Commerce POC ',
-  githubId: 'EcommercePoc',
-  githubUrl: 'https://github.com/alangomessilva/',
-  hashtags: ["Ecomm", "Poc", "Java"],
-  description:
-    'E-Commerce POC - Building ',
-  logo: ecommLogo.toString()
-},
-{
-  id: 2,
-  name: 'Hybris Addon Poc',
-  githubId: 'hybrisAddon',
-  githubUrl: 'https://github.com/alangomessilva/hybrisAddon',
-  hashtags: ["Ecomm", "Hybris", "Java"],
-  description:
-    'Addon to Hybris - Building ',
-  logo: ecommLogo.toString()
-}
-]
+import { projects } from "../data/projects";
 
 export default function Projects() {
   return (
-    <Container maxW={'2x1'}>
+    <Container maxW={'2xl'}>
       <Stack
         textAlign={'center'}
         align={'center'}


### PR DESCRIPTION
## Summary
- refactor project list to shared data source
- update Projects page to use shared data
- add links from project cards to detail pages
- implement detailed ProjectDetails page

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684834813de8832c9f5cbe77e10125c4